### PR TITLE
Replace trie.children.remove(idx) by trie.children.splice(idx, 1)

### DIFF
--- a/trie.js
+++ b/trie.js
@@ -159,7 +159,7 @@ var Trie = (function() {
          */
         remove: function(word) {
             walker(word, this, function(trie, idx) {
-                trie.children.remove(idx);
+                trie.children.splice(idx, 1);
             });
         },
         


### PR DESCRIPTION
remove() is not a function on Array.
I don't know the semantic the author was going for:
Did he want to remove the item and shorten the array as with splice()?
(that is the semantic supported by Java collections remove() method).
Or did he want to delete trie.children[idx], leaving an undefined element in the array there ?
I went with the splice() semantic.